### PR TITLE
Fix tests for **gui**

### DIFF
--- a/modules/gui/tests/CMakeLists.txt
+++ b/modules/gui/tests/CMakeLists.txt
@@ -5,16 +5,16 @@ find_package(GTest REQUIRED)
 set(CMAKE_AUTOMOC ON)
 
 # Library includes all dependencies for tests
-add_library(gui-tests-deps INTERFACE)
-target_link_libraries(gui-tests-deps INTERFACE Qt::Test GTest::gtest GTest::gmock gui files-search-mocks files-search)
+add_library(gui-tests-deps STATIC)
+target_link_libraries(gui-tests-deps PUBLIC Qt::Test GTest::gtest GTest::gmock gui files-search-mocks files-search)
 # Enable access in tests into implementation folder
-target_include_directories(gui-tests-deps INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/../src")
+target_include_directories(gui-tests-deps PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../src")
 # Add current `include` directory into the include folders
-target_include_directories(gui-tests-deps INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_include_directories(gui-tests-deps PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 # Enable current source directory as include folder for local mocks
-target_include_directories(gui-tests-deps INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_include_directories(gui-tests-deps PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 # Add main.cpp as a source file, so any target that links this lib will have it transitively
-target_sources(gui-tests-deps INTERFACE main.cpp)
+target_sources(gui-tests-deps PUBLIC main.cpp)
 
 # Add executable with tests
 add_executable(gui-unit-test
@@ -29,10 +29,7 @@ target_link_libraries(gui-unit-test gui-tests-deps)
 gtest_discover_tests(gui-unit-test
                      DISCOVERY_MODE PRE_TEST
                      PROPERTIES  
-                       LABELS UNIT_TEST
-                       ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
-
-)
+                       LABELS UNIT_TEST)
 
 # Add executable with integration tests
 add_executable(gui-integration-test
@@ -45,5 +42,4 @@ target_link_libraries(gui-integration-test gui-tests-deps)
 gtest_discover_tests(gui-integration-test
                      DISCOVERY_MODE PRE_TEST
                      PROPERTIES  
-                        LABELS INTEGRATION_TEST
-                        ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+                        LABELS INTEGRATION_TEST)

--- a/modules/gui/tests/main.cpp
+++ b/modules/gui/tests/main.cpp
@@ -6,10 +6,10 @@
 
 int main(int argc, char *argv[]) {
   QApplication app{argc, argv};
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::InitGoogleMock(&argc, argv);
 
-  QTimer::singleShot(0, [&]() {
-    ::testing::InitGoogleTest(&argc, argv);
-    ::testing::InitGoogleMock(&argc, argv);
+  QTimer::singleShot(0, [&app]() {
     auto testResult = RUN_ALL_TESTS();
     app.exit(testResult);
   });


### PR DESCRIPTION
Move initialization of GTest and GMock
out of timer callback.

Turn `gui-tests-deps` into a static lib.