### PR TITLE
Use GTest matcher for `QSignalSpy`

### DIFF
--- a/modules/gui/tests/PlainTextMatchCollectorTest.cpp
+++ b/modules/gui/tests/PlainTextMatchCollectorTest.cpp
@@ -1,25 +1,25 @@
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
 #include <QPlainTextEdit>
 #include <QSignalSpy>
 #include <QTest>
-#include <gtest/gtest.h>
 
 #include "impl/PlainTextMatchCollector.h"
 
 using namespace gui;
+using ::testing::ElementsAre;
 
 TEST(PlainTextMatchCollectorTest, failure) {
-   // Create tested class
+  // Create tested class
   PlainTextMatchCollector collector;
   // Connect spy to the signal to collect if something is emitted
   QSignalSpy spy(&collector, &PlainTextMatchCollector::append);
   // Call the function and expect that signal will be emitted
   collector.failed("test/my-file.txt");
-  // Check the number of signals generated
-  ASSERT_EQ(spy.count(), 1);
-  // Obtain parameters for the first generated signal
-  auto arguments = spy.takeFirst();
-  // Compare result for the first signal with expected value
-  EXPECT_EQ(arguments.at(0).toString(), "Filed to parse: test/my-file.txt");
+  // Check the generated signal has expected parameters
+  EXPECT_THAT(
+      spy, ElementsAre(QList<QVariant>({"Filed to parse: test/my-file.txt"})));
 }
 
 TEST(PlainTextMatchCollectorTest, startFileAndMatch) {
@@ -32,16 +32,7 @@ TEST(PlainTextMatchCollectorTest, startFileAndMatch) {
   collector.startFile("test/my-file.txt");
   collector.matchedLine("test line");
 
-  // Check that two signals are generated
-  ASSERT_EQ(spy.count(), 2);
-
-  // Get parameters for the first signal
-  auto first = spy.at(0);
-  // Check that first parameter contains expected string
-  EXPECT_EQ(first.at(0).toString(), "Start file:test/my-file.txt");
-
-  // Obtain parameters for the second generated signal
-  auto second = spy.at(1);
-  // Test that parameter has expected content
-  EXPECT_EQ(second.at(0).toString(), "  test line");
+  // Check the generated two signals has expected parameters
+  EXPECT_THAT(spy, ElementsAre(QList<QVariant>({"Start file:test/my-file.txt"}),
+                               QList<QVariant>({"  test line"})));
 }

--- a/modules/gui/tests/SearchWorkerTest.cpp
+++ b/modules/gui/tests/SearchWorkerTest.cpp
@@ -11,8 +11,8 @@
 using namespace gui;
 using namespace files_search;
 
-using match_search::testing::IsExpected;
 using ::testing::_;
+using ::testing::ElementsAre;
 using ::testing::Return;
 using ::testing::StrictMock;
 
@@ -38,16 +38,7 @@ TEST(SearchWorkerTest, paramForwarded) {
 
   // Check that signal about search start is emitted
   ASSERT_EQ(searchStarted.count(), 1);
-  // Test that signal about search finish is emitted
-  ASSERT_EQ(searchFinished.count(), 1);
 
-  // Get the parameters of the first generated signal
-  auto arg = searchFinished
-                 .takeFirst()
-                 // Get the first parameter of the generated signal
-                 .at(0)
-                 // Cast that parameter to the `std::expected`
-                 .value<std::expected<void, std::string>>();
-  // Test that `std::expected` contains a value
-  EXPECT_THAT(arg, IsExpected());
+  EXPECT_THAT(searchFinished, ElementsAre(QList({QVariant::fromValue(
+                                  std::expected<void, std::string>{})})));
 }


### PR DESCRIPTION
Apply GTest matchers to check if `QSignalSpy` contains expected signals generated